### PR TITLE
Fix issue where list items still have discs

### DIFF
--- a/static/css/bookshelf.css
+++ b/static/css/bookshelf.css
@@ -11,6 +11,7 @@ ul.bookshelf.bookshelf {
 ul.bookshelf.bookshelf li {
   margin: 0;
   padding: 0;
+  list-style-type: none !important;
 }
 
 ul.bookshelf.bookshelf li img.bookshelf__cover {


### PR DESCRIPTION
Currently, at least on some themes, the `list-style-type: none !important` on the ul element is overridden by existing `list-style-type: disc !important` on the li element. This fixes the problem.

Example available at https://micro.esjewett.com/reading/

<img width="662" alt="CleanShot 2022-12-09 at 08 09 00@2x" src="https://user-images.githubusercontent.com/4822/206720597-869def37-932b-45a0-92e7-64e98abbc23c.png">
